### PR TITLE
Comment unimplemented faction variants, fix tank

### DIFF
--- a/Factions/Islamic Republic of Iran/Modern/vehicles_IranianArmy.sqf
+++ b/Factions/Islamic Republic of Iran/Modern/vehicles_IranianArmy.sqf
@@ -35,7 +35,7 @@ _availableVehicles =
 
 	['MBT', 
 		[
-			['LOP_IRAN_T72BA']
+			['LOP_IRAN_T72BA', 4]
 		]
 	],
 

--- a/Factions/Islamic Republic of Iran/variantlist.sqf
+++ b/Factions/Islamic Republic of Iran/variantlist.sqf
@@ -1,7 +1,7 @@
 _avialableVariants = [
 					  "--------- Army ---------",
-					  "IranianArmy Modern",
-					  "Islamic Revolutionary Guard Late"
+					  "IranianArmy Modern"
+					  //"Islamic Revolutionary Guard Late"
 					  ];
 
 _avialableVariants

--- a/Factions/Israel Defense Forces/variantlist.sqf
+++ b/Factions/Israel Defense Forces/variantlist.sqf
@@ -1,6 +1,7 @@
 _avialableVariants = ["--------- Army ---------",
-					  "Army(D) Modern",
-					  "--- Special Forces ---",
-					  "Sayeret(WD) Modern"];
+					  "Army(D) Modern"
+					  //"--- Special Forces ---",
+					  //"Sayeret(WD) Modern"
+					  ];
 
 _avialableVariants

--- a/Factions/Norwegian Armed Forces/variantlist.sqf
+++ b/Factions/Norwegian Armed Forces/variantlist.sqf
@@ -2,7 +2,8 @@ _avialableVariants = [
 	                  "--------- Army ---------",
 	                  "Army(WD) Modern",
                       "Army(W) Modern",
-					  "--- Special Forces ---",
-                      "Jegertroppen Modern"];
+					  //"--- Special Forces ---",
+                      //"Jegertroppen Modern"
+                      ];
 
 _avialableVariants


### PR DESCRIPTION
- Comment out unimplemented faction variants. They cause errors when clicked and break my database generation script.
- Give the tank without listed cargo capacity the capacity of 4.
- These changes have not been tested in the game!